### PR TITLE
Point the README at scriv and mark gg archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # gg
 
+> [!IMPORTANT]
+> **gg is archived and superseded by [scriv](https://github.com/joakimen/scriv).**
+>
+> `gg github clone` is now `scriv repo clone`: the same interactive,
+> multi-select, concurrent clone, plus previews, existing checkouts marked and
+> skipped, and per-repository failure reporting. Authentication is handled by
+> `gh` rather than a token in the system keyring, so `gg github login` has no
+> successor and needs none — run `gh auth login`.
+>
+> ```sh
+> brew uninstall joakimen/tap/gg
+> mise use -g github:joakimen/scriv
+> ```
+>
+> This repository stays up for reference only. It receives no further changes.
+
 gg - Go GitHub
 
 Convenience CLI for some GitHub operations.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,12 @@
 # gg
 
 > [!IMPORTANT]
-> **gg is archived and superseded by [scriv](https://github.com/joakimen/scriv).**
->
-> `gg github clone` is now `scriv repo clone`: the same interactive,
-> multi-select, concurrent clone, plus previews, existing checkouts marked and
-> skipped, and per-repository failure reporting. Authentication is handled by
-> `gh` rather than a token in the system keyring, so `gg github login` has no
-> successor and needs none — run `gh auth login`.
+> **archived and superseded by [scriv](https://github.com/joakimen/scriv).**
 >
 > ```sh
 > brew uninstall joakimen/tap/gg
 > mise use -g github:joakimen/scriv
 > ```
->
-> This repository stays up for reference only. It receives no further changes.
 
 gg - Go GitHub
 


### PR DESCRIPTION
scriv supersedes gg. `gg github clone` is `scriv repo clone`, with previews, existing checkouts marked and skipped, and per-repository failure reporting; authentication moves to `gh auth`, so `gg github login` has no successor and needs none.

Adds an `[!IMPORTANT]` callout at the top of the README with the migration commands. The repository is archived immediately after this merges.